### PR TITLE
Add a new life hack to skip orientation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently, this mod includes the following life hacks:
   default, see the [Configuration](#Configuration) section for details.
 - **Better Experiments** by [dmarcuse](https://github.com/dmarcuse) - Automatically resumes paused experiments when
   re-entering the correct region, and ignores animation state.
+- **Skip Orientation** by [tgrkzus](https://github.com/tgrkzus) - New campaigns default to skipping the orientation
 ## Installation
 ### Recommended
 1. Use [CKAN](https://github.com/KSP-CKAN/CKAN/releases/latest) to download and install Kerbal Life Hacks.

--- a/src/KerbalLifeHacks/Hacks/SkipOrientation/SkipOrientation.cs
+++ b/src/KerbalLifeHacks/Hacks/SkipOrientation/SkipOrientation.cs
@@ -5,14 +5,11 @@ using KSP.VFX;
 
 namespace KerbalLifeHacks.Hacks.SkipOrientation;
 
-[Hack("Skip Orientation")]
+[Hack("Skip Orientation", false)]
 public class SkipOrientation: BaseHack
 {
-    public static SkipOrientation Instance;
-
     public override void OnInitialized()
     {
-        Instance = this;
         HarmonyInstance.PatchAll(typeof(SkipOrientation));
     }
     

--- a/src/KerbalLifeHacks/Hacks/SkipOrientation/SkipOrientation.cs
+++ b/src/KerbalLifeHacks/Hacks/SkipOrientation/SkipOrientation.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using KSP.Game;
+using KSP.Messages;
+using KSP.VFX;
+
+namespace KerbalLifeHacks.Hacks.SkipOrientation;
+
+[Hack("Skip Orientation")]
+public class SkipOrientation: BaseHack
+{
+    public static SkipOrientation Instance;
+
+    public override void OnInitialized()
+    {
+        Instance = this;
+        HarmonyInstance.PatchAll(typeof(SkipOrientation));
+    }
+    
+    /// <summary>
+    /// By default KSP.Game.CreateCampaignMenu._isFTUEEnabled is set to true
+    /// This patch will set it to false always, after the new campaign menu is opened.
+    /// </summary>
+    [HarmonyPatch(typeof(CreateCampaignMenu), nameof(CreateCampaignMenu.OnEnable), MethodType.Normal)]
+    [HarmonyPostfix]
+    public static void OrientationStartDisabled(CreateCampaignMenu __instance)
+    {
+        __instance._isFTUEEnabled.SetValue(false);
+    }
+}


### PR DESCRIPTION
Hi, I'm assume this repo is accepting contributions.
I thought I'd try my hand at KSP2 modding with something small like this.

By default the orientation is always on, which I've caught myself on a few times now and had to skip the video/tutorial I don't care about after the first time I saw it.
I'm assuming anyone else who's installing mods also probably doesn't care for the orientation any more.

Testing by hand this change appears to work for me.